### PR TITLE
Import getTweetServerHandle, not getTweetSenderId

### DIFF
--- a/lib/twitter/handler/verifyTweetFromFriend.js
+++ b/lib/twitter/handler/verifyTweetFromFriend.js
@@ -1,9 +1,9 @@
 const { contains } = require('ramda')
-const { getTweetSenderId } = require('../../helper/tweet')
+const { getTweetSenderHandle } = require('../../helper/tweet')
 
 module.exports = (twitter, tweet) => {
   return new Promise((resolve, reject) => {
-    const senderId = getTweetSenderId(tweet)
+    const senderId = getTweetSenderHandle(tweet)
     twitter
       .getFriendsList()
       .then(list => resolve(contains(senderId, list)))


### PR DESCRIPTION
The unit tests were failing, because the tweet helper is exporting
`getTweetSenderHandle` and not `getTweetSenderId`. I am not
sure why this did not cause issues in production, but the unit
tests failed. So simply renaming the import should fix the situation.